### PR TITLE
DM-12256: Incorporate AssociationTask into ap_pipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 *.so
 *~
+pytest_session.txt
 .cache
 .sconf_temp
 .sconsign.dblite

--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -15,17 +15,15 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
     CALIBINGESTED_DIR = 'calibingested'
     PROCESSED_DIR = 'processed'
     DIFFIM_DIR = 'diffim'
-    OUTPUT_DIRS = [INGESTED_DIR, CALIBINGESTED_DIR, PROCESSED_DIR, DIFFIM_DIR]
 
     def testGetOutputRepos(self):
         '''
         Test that the output repos are constructed properly
         '''
-        repos = ap_pipe.get_output_repos('.', self.OUTPUT_DIRS)
-        self.assertEqual(repos[0], './ingested')
-        self.assertEqual(repos[1], './calibingested')
-        self.assertEqual(repos[2], './processed')
-        self.assertEqual(repos[3], './diffim')
+        self.assertEqual(ap_pipe.get_output_repo('.', self.INGESTED_DIR), './ingested')
+        self.assertEqual(ap_pipe.get_output_repo('.', self.CALIBINGESTED_DIR), './calibingested')
+        self.assertEqual(ap_pipe.get_output_repo('.', self.PROCESSED_DIR), './processed')
+        self.assertEqual(ap_pipe.get_output_repo('.', self.DIFFIM_DIR), './diffim')
 
 #    def testDoIngest(self):
         # test something

--- a/ups/ap_pipe.table
+++ b/ups/ap_pipe.table
@@ -11,6 +11,7 @@ setupRequired(pex_exceptions >= 4.6.0.0)
 setupRequired(ndarray)
 
 setupRequired(obs_decam)
+setupRequired(ap_association)
 
 # The following is boilerplate for all packages.
 # See Tech Note DMTN-001 for details on LSST_LIBRARY_PATH


### PR DESCRIPTION
This PR adds a wrapper for `AssociationTask` and calls it from `runPipelineAlone()`. The wrapper is treated as analogously as possible to the other pipeline steps.