### PR TITLE
DM-12535: Wrap ap_verify and run it over HITS dataset

### DIFF
--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -850,6 +850,10 @@ def _deStringDataId(dataId):
     dataId: `dict`
         The dataId to be cleaned up.
     '''
+    try:
+        basestring
+    except NameError:
+        basestring = str
     integer = re.compile('^\s*[+-]?\d+\s*$')
     for key, value in dataId.items():
         if isinstance(value, basestring) and integer.match(value) is not None:


### PR DESCRIPTION
This patch allows the user to disable `ap_pipe`'s short-circuiting, which causes problems with multi-visit or multi-CCD runs. It also fixes a Python 3 bug introduced in #7.