### PR TITLE
DM-13163: Refactor ap_pipe to use CmdLineTask primitives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: python
+matrix:
+  include:
+    - python: '3.6'
+      install:
+      - pip install flake8
+      script: flake8
+

--- a/bin.src/ap_pipe.py
+++ b/bin.src/ap_pipe.py
@@ -21,7 +21,7 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 
-from lsst.ap.pipe import runPipelineAlone
+from lsst.ap.pipe import ApPipeTask
 
 if __name__ == '__main__':
-    runPipelineAlone()
+    ApPipeTask.parseAndRun()

--- a/config/calexpTemplates.py
+++ b/config/calexpTemplates.py
@@ -1,0 +1,6 @@
+from lsst.ip.diffim import GetCalexpAsTemplateTask
+
+config.differencer.getTemplate.retarget(GetCalexpAsTemplateTask)
+config.differencer.doSelectSources = True
+config.differencer.detection.thresholdValue = 5.0
+config.differencer.doDecorrelation = True

--- a/config/makeCoaddTempExp_goodSeeing.py
+++ b/config/makeCoaddTempExp_goodSeeing.py
@@ -1,11 +1,11 @@
 from lsst.ap.pipe import MaxPsfWcsSelectImagesTask
 
-config.bgSubtracted=True
+config.bgSubtracted = True
 
-# changing coaddName from deep requires modifying the obs_ package--wait 
+# changing coaddName from deep requires modifying the obs_ package--wait
 # until after upcoming RFD
-#config.coaddName='goodSeeing'
+# config.coaddName='goodSeeing'
 
 config.select.retarget(MaxPsfWcsSelectImagesTask)
-config.makePsfMatched=True
-config.makeDirect=True
+config.makePsfMatched = True
+config.makeDirect = True

--- a/python/lsst/ap/pipe/apPipeParser.py
+++ b/python/lsst/ap/pipe/apPipeParser.py
@@ -62,9 +62,7 @@ class ApPipeParser(pipeBase.ArgumentParser):
         self.add_id_argument("--templateId", inputDataset, doMakeDataRefList=True,
                              help="Optional template data ID (visit only), e.g. --templateId visit=410929")
 
-        self.add_argument('--skip', action='store_true',
-                          help="Skip pipeline steps that have already been started. "
-                          "Only useful if --clobber-output not used.")
+        self.addReuseOption(['ccdProcessor', 'differencer', 'associator'])
 
     # TODO: workaround for lack of support for multi-input butlers; see DM-11865
     # Can't delegate to pipeBase.ArgumentParser.parse_args because creating the

--- a/python/lsst/ap/pipe/apPipeParser.py
+++ b/python/lsst/ap/pipe/apPipeParser.py
@@ -1,0 +1,452 @@
+#
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# salong with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+__all__ = ['ApPipeParser']
+
+import argparse
+import fnmatch
+import os
+import re
+import shutil
+import sys
+
+import lsst.log as lsstLog
+import lsst.pex.config as pexConfig
+import lsst.daf.persistence as dafPersist
+import lsst.pipe.base as pipeBase
+
+DEFAULT_INPUT_NAME = "PIPE_INPUT_ROOT"
+DEFAULT_CALIB_NAME = "PIPE_CALIB_ROOT"
+DEFAULT_OUTPUT_NAME = "PIPE_OUTPUT_ROOT"
+
+
+class ApPipeParser(pipeBase.ArgumentParser):
+    """Custom argument parser to handle multiple input repos.
+    """
+
+    def __init__(self, *args, **kwargs):
+        pipeBase.ArgumentParser.__init__(
+            self,
+            description='Process raw decam images with MasterCals '
+                        'from basic processing --> source association',
+            *args,
+            **kwargs)
+        inputDataset = 'raw'
+        self.add_id_argument("--id", inputDataset,
+                             help="data IDs, e.g. --id visit=12345 ccd=1,2^0,3")
+
+        self.add_argument('--template', dest='rawTemplate',
+                          help="path to input template repository, relative to $%s" % DEFAULT_INPUT_NAME)
+        self.add_id_argument("--templateId", inputDataset, doMakeDataRefList=True,
+                             help="Optional template data ID (visit only), e.g. --templateId visit=410929")
+
+        self.add_argument('--skip', action='store_true',
+                          help="Skip pipeline steps that have already been started. "
+                          "Only useful if --clobber-output not used.")
+
+    # TODO: workaround for lack of support for multi-input butlers; see DM-11865
+    # Can't delegate to pipeBase.ArgumentParser.parse_args because creating the
+    # Butler more than once causes repo conflicts
+    def parse_args(self, config, args=None, log=None, override=None):
+        """Parse arguments for a command-line task.
+
+        Parameters
+        ----------
+        config : `lsst.pex.config.Config`
+            Config for the task being run.
+        args : `list`, optional
+            Argument list; if `None` then ``sys.argv[1:]`` is used.
+        log : `lsst.log.Log`, optional
+            `~lsst.log.Log` instance; if `None` use the default log.
+        override : callable, optional
+            A config override function. It must take the root config object as its only argument and must
+            modify the config in place. This function is called after camera-specific overrides files are
+            applied, and before command-line config overrides are applied (thus allowing the user the final
+            word).
+
+        Returns
+        -------
+        namespace : `argparse.Namespace`
+            A `~argparse.Namespace` instance containing fields:
+
+            - ``camera``: camera name.
+            - ``config``: the supplied config with all overrides applied, validated and frozen.
+            - ``butler``: a `lsst.daf.persistence.Butler` for the data.
+            - An entry for each of the data ID arguments registered by `add_id_argument`,
+              the value of which is a `~lsst.pipe.base.DataIdArgument` that includes public elements
+              ``idList`` and ``refList``.
+            - ``log``: a `lsst.log` Log.
+            - An entry for each command-line argument, with the following exceptions:
+              - config is the supplied config, suitably updated.
+              - configfile, id and loglevel are all missing.
+            - ``obsPkg``: name of the ``obs_`` package for this camera.
+        """
+        if args is None:
+            args = sys.argv[1:]
+
+        if len(args) < 1 or args[0].startswith("-") or args[0].startswith("@"):
+            self.print_help()
+            if len(args) == 1 and args[0] in ("-h", "--help"):
+                self.exit()
+            else:
+                self.exit("%s: error: Must specify input as first argument" % self.prog)
+
+        # Note that --rerun may change namespace.input, but if it does we verify that the
+        # new input has the same mapper class.
+        namespace = argparse.Namespace()
+        namespace.input = _fixPath(DEFAULT_INPUT_NAME, args[0])
+        if not os.path.isdir(namespace.input):
+            self.error("Error: input=%r not found" % (namespace.input,))
+
+        namespace.config = config
+        namespace.log = log if log is not None else lsstLog.Log.getDefaultLogger()
+        mapperClass = dafPersist.Butler.getMapperClass(namespace.input)
+        namespace.camera = mapperClass.getCameraName()
+        namespace.obsPkg = mapperClass.getPackageName()
+
+        self.handleCamera(namespace)
+
+        self._applyInitialOverrides(namespace)
+        if override is not None:
+            override(namespace.config)
+
+        # Add data ID containers to namespace
+        for dataIdArgument in self._dataIdArgDict.values():
+            setattr(namespace, dataIdArgument.name, dataIdArgument.ContainerClass(level=dataIdArgument.level))
+
+        namespace = argparse.ArgumentParser.parse_args(self, args=args, namespace=namespace)
+        del namespace.configfile
+
+        self._parseDirectories(namespace)
+        namespace.template = _fixPath(DEFAULT_INPUT_NAME, namespace.rawTemplate)
+        del namespace.rawTemplate
+
+        if namespace.clobberOutput:
+            if namespace.output is None:
+                self.error("--clobber-output is only valid with --output or --rerun")
+            elif namespace.output == namespace.input:
+                self.error("--clobber-output is not valid when the output and input repos are the same")
+            if os.path.exists(namespace.output):
+                namespace.log.info("Removing output repo %s for --clobber-output", namespace.output)
+                shutil.rmtree(namespace.output)
+
+        namespace.log.debug("input=%s", namespace.input)
+        namespace.log.debug("calib=%s", namespace.calib)
+        namespace.log.debug("output=%s", namespace.output)
+        namespace.log.debug("template=%s", namespace.template)
+
+        obeyShowArgument(namespace.show, namespace.config, exit=False)
+
+        # No environment variable or --output or --rerun specified.
+        if self.requireOutput and namespace.output is None and namespace.rerun is None:
+            self.error("no output directory specified.\n"
+                       "An output directory must be specified with the --output or --rerun\n"
+                       "command-line arguments.\n")
+
+        self._makeButler(namespace)
+
+        # convert data in each of the identifier lists to proper types
+        # this is done after constructing the butler, hence after parsing the command line,
+        # because it takes a long time to construct a butler
+        self._processDataIds(namespace)
+        if "data" in namespace.show:
+            for dataIdName in self._dataIdArgDict.keys():
+                for dataRef in getattr(namespace, dataIdName).refList:
+                    print("%s dataRef.dataId = %s" % (dataIdName, dataRef.dataId))
+
+        if namespace.show and "run" not in namespace.show:
+            sys.exit(0)
+
+        if namespace.debug:
+            try:
+                import debug
+                assert debug  # silence pyflakes
+            except ImportError:
+                sys.stderr.write("Warning: no 'debug' module found\n")
+                namespace.debug = False
+
+        del namespace.loglevel
+
+        if namespace.longlog:
+            lsstLog.configure_prop("""
+log4j.rootLogger=INFO, A1
+log4j.appender.A1=ConsoleAppender
+log4j.appender.A1.Target=System.out
+log4j.appender.A1.layout=PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-5p %d{yyyy-MM-ddThh:mm:ss.sss} %c (%X{LABEL})(%F:%L)- %m%n
+""")
+        del namespace.longlog
+
+        namespace.config.validate()
+        namespace.config.freeze()
+
+        return namespace
+
+    def _makeButler(self, namespace):
+        """Create a butler according to parsed command line arguments.
+
+        The butler is stored as ``namespace.butler``.
+
+        Parameters
+        ----------
+        namespace : `argparse.Namespace`
+            a parsed command line containing all information needed to set up a new butler.
+        """
+        butlerArgs = {}  # common arguments for butler elements
+        if namespace.calib:
+            butlerArgs = {'mapperArgs': {'calibRoot': namespace.calib}}
+
+        if namespace.output:
+            inputs = [{'root': namespace.input}]
+            outputs = [{'root': namespace.output, 'mode': 'rw'}]
+        else:
+            inputs = [{'root': namespace.input, 'mode': 'rw'}]
+            outputs = []
+
+        if namespace.template:
+            ApPipeParser._addRepo(inputs, {'root': namespace.template, 'mode': 'r'})
+
+        for repoList in inputs, outputs:
+            for repo in repoList:
+                repo.update(butlerArgs)
+
+        if namespace.output:
+            namespace.butler = dafPersist.Butler(inputs=inputs, outputs=outputs)
+        else:
+            namespace.butler = dafPersist.Butler(outputs=inputs)
+
+    @staticmethod
+    def _addRepo(repos, newRepo):
+        """Add an extra repository to a collection.
+
+        ``newRepo`` will be updated, possibly after validity checks.
+
+        Parameters
+        ----------
+        repos : `iterable` of `dict`
+            The collection of repositories to update. Each element must be a
+            valid input or output argument to an `lsst.daf.persistence.Butler`.
+        newRepo : `dict`
+            The repository to add.
+        """
+        # workaround for DM-13626, blocks DM-11482
+        duplicate = False
+        for repo in repos:
+            if os.path.samefile(repo['root'], newRepo['root']):
+                duplicate = True
+
+        if not duplicate:
+            repos.append(newRepo)
+
+
+# TODO: duplicated code; can remove once DM-11865 resolved
+def _fixPath(defName, path):
+    """Apply environment variable as default root, if present, and abspath.
+
+    Parameters
+    ----------
+    defName : `str`
+        Name of environment variable containing default root path; if the
+        environment variable does not exist then the path is relative to
+        the current working directory
+    path : `str`
+        Path relative to default root path.
+
+    Returns
+    -------
+    abspath : `str`
+        Path that has been expanded, or `None` if the environment variable
+        does not exist and path is `None`.
+    """
+    defRoot = os.environ.get(defName)
+    if defRoot is None:
+        if path is None:
+            return None
+        return os.path.abspath(path)
+    return os.path.abspath(os.path.join(defRoot, path or ""))
+
+
+# TODO: duplicated code; can remove once DM-11865 resolved
+def obeyShowArgument(showOpts, config=None, exit=False):
+    """Process arguments specified with ``--show`` (but ignores ``"data"``).
+
+    Parameters
+    ----------
+    showOpts : `list` of `str`
+        List of options passed to ``--show``.
+    config : optional
+        The provided config.
+    exit : bool, optional
+        Exit if ``"run"`` isn't included in ``showOpts``.
+
+    Parameters
+    ----------
+    Supports the following options in showOpts:
+
+    - ``config[=PAT]``. Dump all the config entries, or just the ones that match the glob pattern.
+    - ``history=PAT``. Show where the config entries that match the glob pattern were set.
+    - ``tasks``. Show task hierarchy.
+    - ``data``. Ignored; to be processed by caller.
+    - ``run``. Keep going (the default behaviour is to exit if --show is specified).
+
+    Calls ``sys.exit(1)`` if any other option found.
+    """
+    if not showOpts:
+        return
+
+    for what in showOpts:
+        showCommand, showArgs = what.split("=", 1) if "=" in what else (what, "")
+
+        if showCommand == "config":
+            matConfig = re.search(r"^(?:config.)?(.+)?", showArgs)
+            pattern = matConfig.group(1)
+            if pattern:
+                class FilteredStream(object):
+                    """A file object that only prints lines that match the glob "pattern"
+
+                    N.b. Newlines are silently discarded and reinserted;  crude but effective.
+                    """
+
+                    def __init__(self, pattern):
+                        # obey case if pattern isn't lowecase or requests NOIGNORECASE
+                        mat = re.search(r"(.*):NOIGNORECASE$", pattern)
+
+                        if mat:
+                            pattern = mat.group(1)
+                            self._pattern = re.compile(fnmatch.translate(pattern))
+                        else:
+                            if pattern != pattern.lower():
+                                print(u"Matching \"%s\" without regard to case "
+                                      "(append :NOIGNORECASE to prevent this)" % (pattern,), file=sys.stdout)
+                            self._pattern = re.compile(fnmatch.translate(pattern), re.IGNORECASE)
+
+                    def write(self, showStr):
+                        showStr = showStr.rstrip()
+                        # Strip off doc string line(s) and cut off at "=" for string matching
+                        matchStr = showStr.split("\n")[-1].split("=")[0]
+                        if self._pattern.search(matchStr):
+                            print(u"\n" + showStr)
+
+                fd = FilteredStream(pattern)
+            else:
+                fd = sys.stdout
+
+            config.saveToStream(fd, "config")
+        elif showCommand == "history":
+            matHistory = re.search(r"^(?:config.)?(.+)?", showArgs)
+            pattern = matHistory.group(1)
+            if not pattern:
+                print("Please provide a value with --show history (e.g. history=XXX)", file=sys.stderr)
+                sys.exit(1)
+
+            pattern = pattern.split(".")
+            cpath, cname = pattern[:-1], pattern[-1]
+            hconfig = config            # the config that we're interested in
+            for i, cpt in enumerate(cpath):
+                try:
+                    hconfig = getattr(hconfig, cpt)
+                except AttributeError:
+                    print("Error: configuration %s has no subconfig %s" %
+                          (".".join(["config"] + cpath[:i]), cpt), file=sys.stderr)
+
+                    sys.exit(1)
+
+            try:
+                print(pexConfig.history.format(hconfig, cname))
+            except KeyError:
+                print("Error: %s has no field %s" % (".".join(["config"] + cpath), cname), file=sys.stderr)
+                sys.exit(1)
+
+        elif showCommand == "data":
+            pass
+        elif showCommand == "run":
+            pass
+        elif showCommand == "tasks":
+            showTaskHierarchy(config)
+        else:
+            print(u"Unknown value for show: %s (choose from '%s')" %
+                  (what, "', '".join("config[=XXX] data history=XXX tasks run".split())), file=sys.stderr)
+            sys.exit(1)
+
+    if exit and "run" not in showOpts:
+        sys.exit(0)
+
+
+def showTaskHierarchy(config):
+    """Print task hierarchy to stdout.
+
+    Parameters
+    ----------
+    config : `lsst.pex.config.Config`
+        Configuration to process.
+    """
+    print(u"Subtasks:")
+    taskDict = getTaskDict(config=config)
+
+    fieldNameList = sorted(taskDict.keys())
+    for fieldName in fieldNameList:
+        taskName = taskDict[fieldName]
+        print(u"%s: %s" % (fieldName, taskName))
+
+
+def getTaskDict(config, taskDict=None, baseName=""):
+    """Get a dictionary of task info for all subtasks in a config
+
+    Parameters
+    ----------
+    config : `lsst.pex.config.Config`
+        Configuration to process.
+    taskDict : `dict`, optional
+        Users should not specify this argument. Supports recursion; if provided, taskDict is updated in
+        place, else a new `dict` is started).
+    baseName : `str`, optional
+        Users should not specify this argument. It is only used for recursion: if a non-empty string then a
+        period is appended and the result is used as a prefix for additional entries in taskDict; otherwise
+        no prefix is used.
+
+    Returns
+    -------
+    taskDict : `dict`
+        Keys are config field names, values are task names.
+
+    Notes
+    -----
+    This function is designed to be called recursively. The user should call with only a config
+    (leaving taskDict and baseName at their default values).
+    """
+    if taskDict is None:
+        taskDict = dict()
+    for fieldName, field in config.items():
+        if hasattr(field, "value") and hasattr(field, "target"):
+            subConfig = field.value
+            if isinstance(subConfig, pexConfig.Config):
+                subBaseName = "%s.%s" % (baseName, fieldName) if baseName else fieldName
+                try:
+                    taskName = "%s.%s" % (field.target.__module__, field.target.__name__)
+                except Exception:
+                    taskName = repr(field.target)
+                taskDict[subBaseName] = taskName
+                getTaskDict(config=subConfig, taskDict=taskDict, baseName=subBaseName)
+    return taskDict

--- a/python/lsst/ap/pipe/apPipeParser.py
+++ b/python/lsst/ap/pipe/apPipeParser.py
@@ -23,7 +23,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-__all__ = ['ApPipeParser']
+__all__ = ["ApPipeParser"]
 
 import argparse
 import fnmatch
@@ -49,20 +49,20 @@ class ApPipeParser(pipeBase.ArgumentParser):
     def __init__(self, *args, **kwargs):
         pipeBase.ArgumentParser.__init__(
             self,
-            description='Process raw decam images with MasterCals '
-                        'from basic processing --> source association',
+            description = "Process raw decam images with MasterCals "
+                          "from basic processing --> source association",
             *args,
             **kwargs)
-        inputDataset = 'raw'
+        inputDataset = "raw"
         self.add_id_argument("--id", inputDataset,
-                             help="data IDs, e.g. --id visit=12345 ccd=1,2^0,3")
+                             help = "data IDs, e.g. --id visit=12345 ccd=1,2^0,3")
 
-        self.add_argument('--template', dest='rawTemplate',
-                          help="path to input template repository, relative to $%s" % DEFAULT_INPUT_NAME)
-        self.add_id_argument("--templateId", inputDataset, doMakeDataRefList=True,
-                             help="Optional template data ID (visit only), e.g. --templateId visit=410929")
+        self.add_argument("--template", dest = "rawTemplate",
+                          help = "path to input template repository, relative to $%s" % DEFAULT_INPUT_NAME)
+        self.add_id_argument("--templateId", inputDataset, doMakeDataRefList = True,
+                             help = "Optional template data ID (visit only), e.g. --templateId visit=410929")
 
-        self.addReuseOption(['ccdProcessor', 'differencer', 'associator'])
+        self.addReuseOption(["ccdProcessor", "differencer", "associator"])
 
     # TODO: workaround for lack of support for multi-input butlers; see DM-11865
     # Can't delegate to pipeBase.ArgumentParser.parse_args because creating the
@@ -214,17 +214,17 @@ log4j.appender.A1.layout.ConversionPattern=%-5p %d{yyyy-MM-ddThh:mm:ss.sss} %c (
         """
         butlerArgs = {}  # common arguments for butler elements
         if namespace.calib:
-            butlerArgs = {'mapperArgs': {'calibRoot': namespace.calib}}
+            butlerArgs = {"mapperArgs": {"calibRoot": namespace.calib}}
 
         if namespace.output:
-            inputs = [{'root': namespace.input}]
-            outputs = [{'root': namespace.output, 'mode': 'rw'}]
+            inputs = [{"root": namespace.input}]
+            outputs = [{"root": namespace.output, "mode": "rw"}]
         else:
-            inputs = [{'root': namespace.input, 'mode': 'rw'}]
+            inputs = [{"root": namespace.input, "mode": "rw"}]
             outputs = []
 
         if namespace.template:
-            ApPipeParser._addRepo(inputs, {'root': namespace.template, 'mode': 'r'})
+            ApPipeParser._addRepo(inputs, {"root": namespace.template, "mode": "r"})
 
         for repoList in inputs, outputs:
             for repo in repoList:
@@ -252,7 +252,7 @@ log4j.appender.A1.layout.ConversionPattern=%-5p %d{yyyy-MM-ddThh:mm:ss.sss} %c (
         # workaround for DM-13626, blocks DM-11482
         duplicate = False
         for repo in repos:
-            if os.path.samefile(repo['root'], newRepo['root']):
+            if os.path.samefile(repo["root"], newRepo["root"]):
                 duplicate = True
 
         if not duplicate:

--- a/python/lsst/ap/pipe/apPipeTaskRunner.py
+++ b/python/lsst/ap/pipe/apPipeTaskRunner.py
@@ -69,8 +69,8 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
         # Hack to allow makeTask(args). Remove once DM-11767 (or possibly DM-13672) resolved
         dbFile = os.path.join(parsedCmd.output, 'association.db')
         argDict = dict(
-            # Temporary workaround for no custom parser.
-            templateIds=[{'visit': 410929}],
+            templateIds=parsedCmd.templateId.idList,
+            skip=parsedCmd.skip,
             **kwargs
         )
         butler = parsedCmd.butler

--- a/python/lsst/ap/pipe/apPipeTaskRunner.py
+++ b/python/lsst/ap/pipe/apPipeTaskRunner.py
@@ -23,7 +23,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-__all__ = ['ApPipeTaskRunner']
+__all__ = ["ApPipeTaskRunner"]
 
 import os
 import sys
@@ -54,12 +54,12 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
         """
         if parsedCmd is not None:
             butler = parsedCmd.butler
-            dbFile = os.path.join(parsedCmd.output, 'association.db')
+            dbFile = os.path.join(parsedCmd.output, "association.db")
         elif args is not None:
             dbFile, dataRef, _ = args
             butler = dataRef.butlerSubset.butler
         else:
-            raise RuntimeError('parsedCmd or args must be specified')
+            raise RuntimeError("parsedCmd or args must be specified")
         return self.TaskClass(config=self.config, log=self.log, butler=butler, dbFile=dbFile)
 
     @staticmethod
@@ -67,7 +67,7 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
         """Get a list of (dbFile, rawRef, calexpRef, kwargs) for `TaskRunner.__call__`.
         """
         # Hack to allow makeTask(args). Remove once DM-11767 (or possibly DM-13672) resolved
-        dbFile = os.path.join(parsedCmd.output, 'association.db')
+        dbFile = os.path.join(parsedCmd.output, "association.db")
         argDict = dict(
             templateIds = parsedCmd.templateId.idList,
             reuse = parsedCmd.reuse,
@@ -75,8 +75,8 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
         )
         butler = parsedCmd.butler
         return [(dbFile,
-                 butler.dataRef('raw', **dataId),
-                 dict(calexpRef=butler.dataRef('calexp', **dataId), **argDict))
+                 butler.dataRef("raw", **dataId),
+                 dict(calexpRef=butler.dataRef("calexp", **dataId), **argDict))
                 for dataId in parsedCmd.id.idList]
 
     # TODO: workaround for DM-11767 or DM-13672; can remove once ApPipeTask.__init__ no longer needs dbFile
@@ -142,12 +142,12 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
 
         if self.doReturnResults:
             return pipeBase.Struct(
-                exitStatus=exitStatus,
-                dataRef=dataRef,
-                metadata=task.metadata,
-                result=result,
+                exitStatus = exitStatus,
+                dataRef = dataRef,
+                metadata = task.metadata,
+                result = result,
             )
         else:
             return pipeBase.Struct(
-                exitStatus=exitStatus,
+                exitStatus = exitStatus,
             )

--- a/python/lsst/ap/pipe/apPipeTaskRunner.py
+++ b/python/lsst/ap/pipe/apPipeTaskRunner.py
@@ -1,0 +1,153 @@
+#
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+__all__ = ['ApPipeTaskRunner']
+
+import os
+import sys
+import traceback
+
+import lsst.log
+import lsst.pipe.base as pipeBase
+
+
+class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
+
+    def makeTask(self, parsedCmd=None, args=None):
+        """Construct an ApPipeTask with both a Butler and a database.
+
+        Parameters
+        ----------
+        parsedCmd : `argparse.Namespace`
+            Parsed command-line options, as returned by the `~lsst.pipe.base.ArgumentParser`; if specified
+            then args is ignored.
+        args
+            Args tuple passed to `TaskRunner.__call__`. First argument must be
+            a path to the database file and second argument must be a dataref.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if ``parsedCmd`` and ``args`` are both `None`.
+        """
+        if parsedCmd is not None:
+            butler = parsedCmd.butler
+            dbFile = os.path.join(parsedCmd.output, 'association.db')
+        elif args is not None:
+            dbFile, dataRef, _ = args
+            butler = dataRef.butlerSubset.butler
+        else:
+            raise RuntimeError('parsedCmd or args must be specified')
+        return self.TaskClass(config=self.config, log=self.log, butler=butler, dbFile=dbFile)
+
+    @staticmethod
+    def getTargetList(parsedCmd, **kwargs):
+        """Get a list of (dbFile, rawRef, calexpRef, kwargs) for `TaskRunner.__call__`.
+        """
+        # Hack to allow makeTask(args). Remove once DM-11767 (or possibly DM-13672) resolved
+        dbFile = os.path.join(parsedCmd.output, 'association.db')
+        argDict = dict(
+            # Temporary workaround for no custom parser.
+            templateIds=[{'visit': 410929}],
+            **kwargs
+        )
+        butler = parsedCmd.butler
+        return [(dbFile,
+                 butler.dataRef('raw', **dataId),
+                 dict(calexpRef=butler.dataRef('calexp', **dataId), **argDict))
+                for dataId in parsedCmd.id.idList]
+
+    # TODO: workaround for DM-11767 or DM-13672; can remove once ApPipeTask.__init__ no longer needs dbFile
+    # TODO: find a way to pass the DB argument that doesn't require duplicating TaskRunner.__call__
+    def __call__(self, args):
+        """Run the Task on a single target.
+
+        Parameters
+        ----------
+        args
+            A path to the database file, followed by arguments for Task.run().
+
+        Returns
+        -------
+        struct : `lsst.pipe.base.Struct`
+            Contains these fields if ``doReturnResults`` is `True`:
+
+            - ``dataRef``: the provided data reference.
+            - ``metadata``: task metadata after execution of run.
+            - ``result``: result returned by task run, or `None` if the task fails.
+            - ``exitStatus`: 0 if the task completed successfully, 1 otherwise.
+
+            If ``doReturnResults`` is `False` the struct contains:
+
+            - ``exitStatus`: 0 if the task completed successfully, 1 otherwise.
+        """
+        _, dataRef, kwargs = args
+        if self.log is None:
+            self.log = lsst.log.Log.getDefaultLogger()
+        if hasattr(dataRef, "dataId"):
+            self.log.MDC("LABEL", str(dataRef.dataId))
+        elif isinstance(dataRef, (list, tuple)):
+            self.log.MDC("LABEL", str([ref.dataId for ref in dataRef if hasattr(ref, "dataId")]))
+        task = self.makeTask(args=args)
+        result = None                   # in case the task fails
+        exitStatus = 0                  # exit status for the shell
+        if self.doRaise:
+            result = task.run(dataRef, **kwargs)
+        else:
+            try:
+                result = task.run(dataRef, **kwargs)
+            except Exception as e:
+                # The shell exit value will be the number of dataRefs returning
+                # non-zero, so the actual value used here is lost.
+                exitStatus = 1
+
+                # don't use a try block as we need to preserve the original exception
+                eName = type(e).__name__
+                if hasattr(dataRef, "dataId"):
+                    task.log.fatal("Failed on dataId=%s: %s: %s", dataRef.dataId, eName, e)
+                elif isinstance(dataRef, (list, tuple)):
+                    task.log.fatal("Failed on dataIds=[%s]: %s: %s",
+                                   ", ".join(str(ref.dataId) for ref in dataRef), eName, e)
+                else:
+                    task.log.fatal("Failed on dataRef=%s: %s: %s", dataRef, eName, e)
+
+                if not isinstance(e, pipeBase.TaskError):
+                    traceback.print_exc(file=sys.stderr)
+        task.writeMetadata(dataRef)
+
+        # remove MDC so it does not show up outside of task context
+        self.log.MDCRemove("LABEL")
+
+        if self.doReturnResults:
+            return pipeBase.Struct(
+                exitStatus=exitStatus,
+                dataRef=dataRef,
+                metadata=task.metadata,
+                result=result,
+            )
+        else:
+            return pipeBase.Struct(
+                exitStatus=exitStatus,
+            )

--- a/python/lsst/ap/pipe/apPipeTaskRunner.py
+++ b/python/lsst/ap/pipe/apPipeTaskRunner.py
@@ -69,8 +69,8 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
         # Hack to allow makeTask(args). Remove once DM-11767 (or possibly DM-13672) resolved
         dbFile = os.path.join(parsedCmd.output, 'association.db')
         argDict = dict(
-            templateIds=parsedCmd.templateId.idList,
-            skip=parsedCmd.skip,
+            templateIds = parsedCmd.templateId.idList,
+            reuse = parsedCmd.reuse,
             **kwargs
         )
         butler = parsedCmd.butler

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -386,10 +386,6 @@ def runPipelineAlone():
 
     # Set up repos
     dataId_dict = _parseDataId(dataId)
-    if 'visit' not in dataId_dict.keys():
-        raise RuntimeError('The dataId string is missing \'visit\'')
-    else:  # save the visit number from the dataId
-        visit = dataId_dict['visit']
 
     mapperArgs = {'calibRoot': calib_repo}
     inputs = [{'root': repo, 'mapperArgs': mapperArgs}]
@@ -418,12 +414,12 @@ def runPipelineAlone():
 
     # Run all the tasks in order
     if skip and processedRef.datasetExists('calexp', write=True):
-        log.warn('ProcessCcd has already been run for visit {0}, skipping...'.format(visit))
+        log.warn('ProcessCcd has already been run for {0}, skipping...'.format(rawRef.dataId))
     else:
         doProcessCcd(rawRef)
 
     if skip and processedRef.datasetExists('deepDiff_diaSrc', write=True):
-        log.warn('DiffIm has already been run for visit {0}, skipping...'.format(visit))
+        log.warn('DiffIm has already been run for {0}, skipping...'.format(processedRef.dataId))
     else:
         doDiffIm(processedRef, templateType, template)
 

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -180,8 +180,6 @@ class ApPipeTask(pipeBase.CmdLineTask):
         result : `lsst.pipe.base.Struct`
             Result struct with components:
 
-            - fullMetadata : metadata produced by the run. Intended as a transitional API
-                for ap_verify, and may be removed later (`lsst.daf.base.PropertySet`).
             - l1Database : handle for accessing the final association database, conforming to
                 `ap_association`'s DB access API
             - ccdProcessor : output of `config.ccdProcessor.run` (`lsst.pipe.base.Struct` or `None`).
@@ -214,10 +212,9 @@ class ApPipeTask(pipeBase.CmdLineTask):
         associationResults = self.runAssociation(calexpRef)
 
         return pipeBase.Struct(
-            fullMetadata = self.getFullMetadata(),
             l1Database = associationResults.l1Database,
-            ccdProcessor = processResults.taskResults if processResults else None,
-            differencer = diffImResults.taskResults if diffImResults else None,
+            ccdProcessor = processResults if processResults else None,
+            differencer = diffImResults if diffImResults else None,
             associator = associationResults.taskResults if associationResults else None
         )
 
@@ -236,22 +233,14 @@ class ApPipeTask(pipeBase.CmdLineTask):
         Returns
         -------
         result : `lsst.pipe.base.Struct`
-            Result struct with components:
-
-            - fullMetadata : metadata produced by the Task. Intended as a transitional API
-                for ap_verify, and may be removed later (`lsst.daf.base.PropertySet`).
-            - taskResults : output of `config.ccdProcessor.run` (`lsst.pipe.base.Struct`).
+            Output of `config.ccdProcessor.run`.
 
         Notes
         -----
         The input repository corresponding to ``sensorRef`` must already contain the refcats.
         """
         self.log.info("Running ProcessCcd...")
-        result = self.ccdProcessor.run(sensorRef)
-        return pipeBase.Struct(
-            fullMetadata = self.ccdProcessor.getFullMetadata(),
-            taskResults = result
-        )
+        return self.ccdProcessor.run(sensorRef)
 
     @pipeBase.timeMethod
     def runDiffIm(self, sensorRef, templateIds=None):
@@ -272,18 +261,10 @@ class ApPipeTask(pipeBase.CmdLineTask):
         Returns
         -------
         result : `lsst.pipe.base.Struct`
-            Result struct with components:
-
-            - fullMetadata : metadata produced by the run. Intended as a transitional API
-                for ap_verify, and may be removed later (`lsst.daf.base.PropertySet`).
-            - taskResults : output of `config.differencer.run` (`lsst.pipe.base.Struct`).
+            Output of `config.differencer.run`.
         """
         self.log.info("Running ImageDifference...")
-        result = self.differencer.run(sensorRef, templateIdList=templateIds)
-        return pipeBase.Struct(
-            fullMetadata = self.differencer.getFullMetadata(),
-            taskResults = result
-        )
+        return self.differencer.run(sensorRef, templateIdList=templateIds)
 
     @pipeBase.timeMethod
     def runAssociation(self, sensorRef):
@@ -299,8 +280,6 @@ class ApPipeTask(pipeBase.CmdLineTask):
         result : `lsst.pipe.base.Struct`
             Result struct with components:
 
-            - fullMetadata : metadata produced by the run. Intended as a transitional API
-                for ap_verify, and may be removed later (`lsst.daf.base.PropertySet`).
             - l1Database : handle for accessing the final association database, conforming to
                 `ap_association`'s DB access API
             - taskResults : output of `config.associator.run` (`lsst.pipe.base.Struct`).
@@ -318,7 +297,6 @@ class ApPipeTask(pipeBase.CmdLineTask):
             self.associator.level1_db.close()
 
         return pipeBase.Struct(
-            fullMetadata = self.associator.getFullMetadata(),
             l1Database = self.associator.level1_db,
             taskResults = result
         )

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -38,7 +38,6 @@ import lsst.pipe.base as pipeBase
 from lsst.pipe.tasks.processCcd import ProcessCcdTask
 from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 from lsst.utils import getPackageDir
-from lsst.ip.diffim.getTemplate import GetCalexpAsTemplateTask
 from lsst.pipe.tasks.imageDifference import ImageDifferenceTask
 from lsst.ap.association import AssociationDBSqliteTask, AssociationTask
 
@@ -508,8 +507,7 @@ def runPipelineAlone():
 
     if templateType == 'visit':
         templateIds = [_parseDataId(template)]
-        config.differencer.getTemplate.retarget(GetCalexpAsTemplateTask)
-        config.differencer.doSelectSources = True
+        config.load(os.path.join(getPackageDir('ap_pipe'), 'config', 'calexpTemplates.py'))
     elif templateType == 'coadd':
         templateIds = None
         # Default assumed by ApPipeConfig, no changes needed

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -414,12 +414,12 @@ def runPipelineAlone():
 
     # Run all the tasks in order
     if skip and processedRef.datasetExists('calexp', write=True):
-        log.warn('ProcessCcd has already been run for {0}, skipping...'.format(rawRef.dataId))
+        log.info('ProcessCcd has already been run for {0}, skipping...'.format(rawRef.dataId))
     else:
         doProcessCcd(rawRef)
 
     if skip and processedRef.datasetExists('deepDiff_diaSrc', write=True):
-        log.warn('DiffIm has already been run for {0}, skipping...'.format(processedRef.dataId))
+        log.info('DiffIm has already been run for {0}, skipping...'.format(processedRef.dataId))
     else:
         doDiffIm(processedRef, templateType, template)
 

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -211,7 +211,8 @@ class ApPipeTask(pipeBase.CmdLineTask):
         else:
             processResults = self.runProcessCcd(rawRef)
 
-        if skip and calexpRef.datasetExists('deepDiff_diaSrc', write=True):
+        diffType = self.config.differencer.coaddName
+        if skip and calexpRef.datasetExists(diffType + 'Diff_diaSrc', write=True):
             self.log.info('DiffIm has already been run for {0}, skipping...'.format(calexpRef.dataId))
             diffImResults = None
         else:
@@ -314,9 +315,10 @@ class ApPipeTask(pipeBase.CmdLineTask):
         """
         self.log.info('Running Association...')
 
+        diffType = self.config.differencer.coaddName
         try:
-            catalog = sensorRef.get('deepDiff_diaSrc')
-            exposure = sensorRef.get('deepDiff_differenceExp')
+            catalog = sensorRef.get(diffType + 'Diff_diaSrc')
+            exposure = sensorRef.get(diffType + 'Diff_differenceExp')
             result = self.associator.run(catalog, exposure)
         finally:
             # Stateful AssociationTask will work for now because TaskRunner

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -438,7 +438,6 @@ def runPipelineAlone():
                                         'mapperArgs': mapperArgs})
     rawRef = butler.dataRef('raw', dataId=dataId_dict)
     processedRef = butler.dataRef('calexp', dataId=dataId_dict)
-    differencedRef = butler.dataRef('deepDiff_differenceExp', dataId=dataId_dict)
     # TODO: workaround for DM-11767
     database = os.path.join(output_repo, 'association.db')
 
@@ -468,7 +467,7 @@ def runPipelineAlone():
         doDiffIm(processedRef, templateType, template)
 
     # No reasonable way to check if Association finished successfully
-    doAssociation(differencedRef, database)
+    doAssociation(processedRef, database)
 
     log.info('Prototype AP Pipeline run complete.')
 

--- a/python/lsst/ap/pipe/selectImages.py
+++ b/python/lsst/ap/pipe/selectImages.py
@@ -47,13 +47,12 @@ class MaxPsfWcsSelectImagesTask(WcsSelectImagesTask):
     """
     ConfigClass = MaxPsfWcsSelectImageConfig
 
-    def runDataRef(self, dataRef, coordList, makeDataRefList=True, 
-                   selectDataList=[]):
+    def runDataRef(self, dataRef, coordList, makeDataRefList=True, selectDataList=[]):
         """Select images in the selectDataList that overlap the patch.
 
         Parameters
         ----------
-        coordList : `list` of `Coord` 
+        coordList : `list` of `Coord`
             List of Coord specifying boundary of patch
         selectDataList : `list` of `SelectStruct`
             List of SelectStruct, to consider for selection
@@ -62,7 +61,7 @@ class MaxPsfWcsSelectImagesTask(WcsSelectImagesTask):
 
         Returns
         -------
-        pipe.base.Struct with filtered exposureList and dataRefList 
+        pipe.base.Struct with filtered exposureList and dataRefList
         (if makeDataRefList is True).
 
         Notes
@@ -87,7 +86,7 @@ class MaxPsfWcsSelectImagesTask(WcsSelectImagesTask):
         for data in selectDataList:
             dataRef = data.dataRef
             imageWcs = data.wcs
-            cal = dataRef.get('calexp', immediate=True)
+            cal = dataRef.get("calexp", immediate=True)
             psf_size = cal.getPsf().computeShape().getDeterminantRadius()
             nx, ny = cal.getDimensions()
 
@@ -114,7 +113,7 @@ class MaxPsfWcsSelectImagesTask(WcsSelectImagesTask):
             # size_sigma is in sigma.  Convert to FWHM
             size_fwhm = size_sigma * np.sqrt(8.*np.log(2.))
             if size_fwhm < self.config.maxPsfFwhm and size_fwhm > self.config.minPsfFwhm:
-                self.log.info("%s selected with FWHM of %f pixels"%(dataRef.dataId, size_fwhm))
+                self.log.info("%s selected with FWHM of %f pixels" % (dataRef.dataId, size_fwhm))
                 filteredDataRefList.append(dataRef)
                 filteredExposureInfoList.append(expInfo)
         return pipeBase.Struct(

--- a/python/lsst/ap/pipe/selectImages.py
+++ b/python/lsst/ap/pipe/selectImages.py
@@ -18,7 +18,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# salong with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
 from __future__ import absolute_import, division, print_function

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[flake8]
+max-line-length = 110
+ignore = E133, E226, E228, E251, N802, N803, N806
+exclude =
+  bin,
+  config,
+  doc,
+  **/*/__init__.py,
+  **/*/version.py,
+  tests/.tests
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 E251 N802 N803 N806
+  # For some reason pytest-flake8 doesn't use `exclude` consistently
+  bin/*.py ALL
+  config/*.py ALL
+  doc/*.py ALL

--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -35,10 +35,10 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
     '''
 
 #    def testDoProcessCcd(self):
-        # test something
+#        # test something
 
 #    def testDoDiffIm(self):
-        # test something
+#        # test something
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -34,26 +34,6 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
     TODO: write more tests for DM-11422.
     '''
 
-    INGESTED_DIR = 'ingested'
-    CALIBINGESTED_DIR = 'calibingested'
-    PROCESSED_DIR = 'processed'
-    DIFFIM_DIR = 'diffim'
-
-    def testGetOutputRepos(self):
-        '''
-        Test that the output repos are constructed properly
-        '''
-        self.assertEqual(ap_pipe.get_output_repo('.', self.INGESTED_DIR), './ingested')
-        self.assertEqual(ap_pipe.get_output_repo('.', self.CALIBINGESTED_DIR), './calibingested')
-        self.assertEqual(ap_pipe.get_output_repo('.', self.PROCESSED_DIR), './processed')
-        self.assertEqual(ap_pipe.get_output_repo('.', self.DIFFIM_DIR), './diffim')
-
-#    def testDoIngest(self):
-        # test something
-
-#    def testDoIngestCalibs(self):
-        # test something
-
 #    def testDoProcessCcd(self):
         # test something
 

--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -24,7 +24,6 @@
 from __future__ import absolute_import, division, print_function
 import unittest
 import lsst.utils.tests
-import lsst.ap.pipe as ap_pipe
 
 
 class PipelineTestSuite(lsst.utils.tests.TestCase):

--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -18,7 +18,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# salong with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
 from __future__ import absolute_import, division, print_function


### PR DESCRIPTION
This is a complete refactoring of `ap_pipe`, preserving existing functionality as much as possible (some changes to the command-line interface were unavoidable). No attempt was made to make use of features enabled by `CmdLineTask`, such as parallelism support or `obs_` package handling; such changes are out of scope for the ticket.

`ApPipeTask` requires both a custom runner and a custom parser to support the source association database and input template repositories. Unfortunately, due to limited support for subclassing, this meant duplicating a large amount of code from `pipe.base.TaskRunner` and `pipe.base.ArgumentParser`. I hope we can remove the duplicate code quickly as the indicated tickets get resolved.