### PR TITLE
DM-14359: Fix data ID handling in ap_*

### DIFF
--- a/python/lsst/__init__.py
+++ b/python/lsst/__init__.py
@@ -21,7 +21,5 @@
 # see <https://www.lsstcorp.org/LegalNotices/>.
 #
 
-from __future__ import absolute_import
-
 import pkgutil, lsstimport
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/ap/__init__.py
+++ b/python/lsst/ap/__init__.py
@@ -21,7 +21,5 @@
 # see <https://www.lsstcorp.org/LegalNotices/>.
 #
 
-from __future__ import absolute_import
-
 import pkgutil, lsstimport
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/ap/pipe/__init__.py
+++ b/python/lsst/ap/pipe/__init__.py
@@ -21,7 +21,5 @@
 # see <https://www.lsstcorp.org/LegalNotices/>.
 #
 
-from __future__ import absolute_import
-
 from .ap_pipe import *
 from .selectImages import *

--- a/python/lsst/ap/pipe/apPipeParser.py
+++ b/python/lsst/ap/pipe/apPipeParser.py
@@ -21,8 +21,6 @@
 # salong with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
 __all__ = ["ApPipeParser"]
 
 import argparse

--- a/python/lsst/ap/pipe/apPipeParser.py
+++ b/python/lsst/ap/pipe/apPipeParser.py
@@ -49,18 +49,18 @@ class ApPipeParser(pipeBase.ArgumentParser):
     def __init__(self, *args, **kwargs):
         pipeBase.ArgumentParser.__init__(
             self,
-            description = "Process raw decam images with MasterCals "
-                          "from basic processing --> source association",
+            description="Process raw decam images with MasterCals "
+                        "from basic processing --> source association",
             *args,
             **kwargs)
         inputDataset = "raw"
         self.add_id_argument("--id", inputDataset,
-                             help = "data IDs, e.g. --id visit=12345 ccd=1,2^0,3")
+                             help="data IDs, e.g. --id visit=12345 ccd=1,2^0,3")
 
-        self.add_argument("--template", dest = "rawTemplate",
-                          help = "path to input template repository, relative to $%s" % DEFAULT_INPUT_NAME)
-        self.add_id_argument("--templateId", inputDataset, doMakeDataRefList = True,
-                             help = "Optional template data ID (visit only), e.g. --templateId visit=410929")
+        self.add_argument("--template", dest="rawTemplate",
+                          help="path to input template repository, relative to $%s" % DEFAULT_INPUT_NAME)
+        self.add_id_argument("--templateId", inputDataset, doMakeDataRefList=True,
+                             help="Optional template data ID (visit only), e.g. --templateId visit=410929")
 
         self.addReuseOption(["ccdProcessor", "differencer", "associator"])
 

--- a/python/lsst/ap/pipe/apPipeTaskRunner.py
+++ b/python/lsst/ap/pipe/apPipeTaskRunner.py
@@ -21,8 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
 __all__ = ["ApPipeTaskRunner"]
 
 import os

--- a/python/lsst/ap/pipe/apPipeTaskRunner.py
+++ b/python/lsst/ap/pipe/apPipeTaskRunner.py
@@ -69,8 +69,8 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
         # Hack to allow makeTask(args). Remove once DM-11767 (or possibly DM-13672) resolved
         dbFile = os.path.join(parsedCmd.output, "association.db")
         argDict = dict(
-            templateIds = parsedCmd.templateId.idList,
-            reuse = parsedCmd.reuse,
+            templateIds=parsedCmd.templateId.idList,
+            reuse=parsedCmd.reuse,
             **kwargs
         )
         return [(dbFile, dataRef, argDict) for dataRef in parsedCmd.id.refList]
@@ -107,8 +107,8 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
         elif isinstance(dataRef, (list, tuple)):
             self.log.MDC("LABEL", str([ref.dataId for ref in dataRef if hasattr(ref, "dataId")]))
         task = self.makeTask(args=args)
-        result = None                   # in case the task fails
-        exitStatus = 0                  # exit status for the shell
+        result = None  # in case the task fails
+        exitStatus = 0  # exit status for the shell
         if self.doRaise:
             result = task.run(dataRef, **kwargs)
         else:
@@ -138,12 +138,12 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
 
         if self.doReturnResults:
             return pipeBase.Struct(
-                exitStatus = exitStatus,
-                dataRef = dataRef,
-                metadata = task.metadata,
-                result = result,
+                exitStatus=exitStatus,
+                dataRef=dataRef,
+                metadata=task.metadata,
+                result=result,
             )
         else:
             return pipeBase.Struct(
-                exitStatus = exitStatus,
+                exitStatus=exitStatus,
             )

--- a/python/lsst/ap/pipe/apPipeTaskRunner.py
+++ b/python/lsst/ap/pipe/apPipeTaskRunner.py
@@ -73,11 +73,7 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
             reuse = parsedCmd.reuse,
             **kwargs
         )
-        butler = parsedCmd.butler
-        return [(dbFile,
-                 butler.dataRef("raw", **dataId),
-                 argDict)
-                for dataId in parsedCmd.id.idList]
+        return [(dbFile, dataRef, argDict) for dataRef in parsedCmd.id.refList]
 
     # TODO: workaround for DM-11767 or DM-13672; can remove once ApPipeTask.__init__ no longer needs dbFile
     # TODO: find a way to pass the DB argument that doesn't require duplicating TaskRunner.__call__

--- a/python/lsst/ap/pipe/apPipeTaskRunner.py
+++ b/python/lsst/ap/pipe/apPipeTaskRunner.py
@@ -64,7 +64,7 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
 
     @staticmethod
     def getTargetList(parsedCmd, **kwargs):
-        """Get a list of (dbFile, rawRef, calexpRef, kwargs) for `TaskRunner.__call__`.
+        """Get a list of (dbFile, rawRef, kwargs) for `TaskRunner.__call__`.
         """
         # Hack to allow makeTask(args). Remove once DM-11767 (or possibly DM-13672) resolved
         dbFile = os.path.join(parsedCmd.output, "association.db")
@@ -76,7 +76,7 @@ class ApPipeTaskRunner(pipeBase.ButlerInitializedTaskRunner):
         butler = parsedCmd.butler
         return [(dbFile,
                  butler.dataRef("raw", **dataId),
-                 dict(calexpRef=butler.dataRef("calexp", **dataId), **argDict))
+                 argDict)
                 for dataId in parsedCmd.id.idList]
 
     # TODO: workaround for DM-11767 or DM-13672; can remove once ApPipeTask.__init__ no longer needs dbFile

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -190,6 +190,7 @@ class ApPipeTask(pipeBase.CmdLineTask):
         # TODO: treat as independent jobs (may need SuperTask framework?)
         if templateIds is not None:
             for templateId in templateIds:
+                # templateId is typically visit-only; consider only the same raft/CCD/etc. as rawRef
                 rawTemplateRef = _siblingRef(rawRef, "raw", templateId)
                 calexpTemplateRef = _siblingRef(calexpRef, "calexp", templateId)
                 if "ccdProcessor" not in reuse or not calexpTemplateRef.datasetExists("calexp", write=True):
@@ -329,7 +330,11 @@ def _setupDatabase(configurable):
 
 
 def _siblingRef(original, datasetType, dataId):
-    """Construct a new dataRef from an old one.
+    """Construct a new dataRef using an existing dataRef as a template.
+
+    The typical application is to construct a data ID that differs from an
+    existing ID in one or two keys, but is more specific than expanding a
+    partial data ID would be.
 
     Parameters
     ----------

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -159,7 +159,7 @@ class ApPipeTask(pipeBase.CmdLineTask):
         return configClass(**contents)
 
     @pipeBase.timeMethod
-    def run(self, rawRef, templateIds=None, reuse=[]):
+    def run(self, rawRef, templateIds=None, reuse=None):
         """Execute the ap_pipe pipeline on a single image.
 
         Parameters
@@ -170,8 +170,9 @@ class ApPipeTask(pipeBase.CmdLineTask):
             A list of parsed data IDs for templates to use. Only used if
             ``config.differencer`` is configured to do so. ``differencer`` or
             its subtasks may restrict the allowed IDs.
-        reuse : `list` of `str`
-            The names of all subtasks that may be skipped if their output is present.
+        reuse : `list` of `str`, optional
+            The names of all subtasks that may be skipped if their output is
+            present. Defaults to skipping nothing.
 
         Returns
         -------
@@ -184,6 +185,8 @@ class ApPipeTask(pipeBase.CmdLineTask):
             - differencer : output of `config.differencer.run` (`lsst.pipe.base.Struct` or `None`).
             - associator : output of `config.associator.run` (`lsst.pipe.base.Struct` or `None`).
         """
+        if reuse is None:
+            reuse = []
         # Work around mismatched HDU lists for raw and processed data
         calexpId = rawRef.dataId.copy()
         if 'hdu' in calexpId:

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -44,16 +44,16 @@ class ApPipeConfig(pexConfig.Config):
     """
 
     ccdProcessor = pexConfig.ConfigurableField(
-        target = ProcessCcdTask,
-        doc = "Task used to perform basic image reduction and characterization.",
+        target=ProcessCcdTask,
+        doc="Task used to perform basic image reduction and characterization.",
     )
     differencer = pexConfig.ConfigurableField(
-        target = ImageDifferenceTask,
-        doc = "Task used to do image subtraction and DiaSource detection.",
+        target=ImageDifferenceTask,
+        doc="Task used to do image subtraction and DiaSource detection.",
     )
     associator = pexConfig.ConfigurableField(
-        target = AssociationTask,
-        doc = "Task used to associate DiaSources with DiaObjects.",
+        target=AssociationTask,
+        doc="Task used to associate DiaSources with DiaObjects.",
     )
 
     def setDefaults(self):
@@ -217,10 +217,10 @@ class ApPipeTask(pipeBase.CmdLineTask):
         associationResults = self.runAssociation(calexpRef)
 
         return pipeBase.Struct(
-            l1Database = associationResults.l1Database,
-            ccdProcessor = processResults if processResults else None,
-            differencer = diffImResults if diffImResults else None,
-            associator = associationResults.taskResults if associationResults else None
+            l1Database=associationResults.l1Database,
+            ccdProcessor=processResults if processResults else None,
+            differencer=diffImResults if diffImResults else None,
+            associator=associationResults.taskResults if associationResults else None
         )
 
     @pipeBase.timeMethod
@@ -302,8 +302,8 @@ class ApPipeTask(pipeBase.CmdLineTask):
             self.associator.level1_db.close()
 
         return pipeBase.Struct(
-            l1Database = self.associator.level1_db,
-            taskResults = result
+            l1Database=self.associator.level1_db,
+            taskResults=result
         )
 
     @classmethod
@@ -322,9 +322,9 @@ def _setupDatabase(configurable):
     Parameters
     ----------
     configurable: `lsst.pex.config.ConfigurableInstance`
-        A ConfigurableInstance with a database-managing class in its `target`
-        field. The API of `target` must expose a `create_tables` method taking
-        no arguments.
+        A ConfigurableInstance with a database-managing class in its ``target``
+        field. The API of ``target`` must expose a ``create_tables`` method
+        taking no arguments.
     """
     db = configurable.apply()
     try:

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -21,8 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
 __all__ = ["ApPipeConfig", "ApPipeTask"]
 
 import os

--- a/python/lsst/ap/pipe/selectImages.py
+++ b/python/lsst/ap/pipe/selectImages.py
@@ -117,6 +117,6 @@ class MaxPsfWcsSelectImagesTask(WcsSelectImagesTask):
                 filteredDataRefList.append(dataRef)
                 filteredExposureInfoList.append(expInfo)
         return pipeBase.Struct(
-            dataRefList = filteredDataRefList if makeDataRefList else None,
-            exposureInfoList = filteredExposureInfoList,
+            dataRefList=filteredDataRefList if makeDataRefList else None,
+            exposureInfoList=filteredExposureInfoList,
         )

--- a/python/lsst/ap/pipe/selectImages.py
+++ b/python/lsst/ap/pipe/selectImages.py
@@ -21,8 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-from builtins import zip
 import numpy as np
 
 import lsst.pex.config as pexConfig

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, E251, N802, N803, N806
+ignore = E133, E226, E228, N802, N803, N806
 exclude =
   bin,
   config,
@@ -11,7 +11,7 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 E251 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806
   # For some reason pytest-flake8 doesn't use `exclude` consistently
   bin/*.py ALL
   config/*.py ALL

--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -21,7 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
 import unittest
 import lsst.utils.tests
 


### PR DESCRIPTION
This PR fixes several bugs in how datarefs were passed to `ApPipeTask`. It also updates `ap_pipe` to current style standards and removes use of `future`.