### PR TITLE
DM-14494: selectImages.py depends on defunct lsst.geom

### DIFF
--- a/python/lsst/ap/pipe/__init__.py
+++ b/python/lsst/ap/pipe/__init__.py
@@ -22,4 +22,3 @@
 #
 
 from .ap_pipe import *
-from .selectImages import *

--- a/python/lsst/ap/pipe/selectImages.py
+++ b/python/lsst/ap/pipe/selectImages.py
@@ -28,7 +28,7 @@ import lsst.pex.exceptions as pexExceptions
 import lsst.afw.geom as afwGeom
 import lsst.pipe.base as pipeBase
 from lsst.pipe.tasks.selectImages import WcsSelectImagesTask, BaseExposureInfo
-from lsst.geom import convexHull
+from lsst.sphgeom import ConvexPolygon
 
 __all__ = ["MaxPsfWcsSelectImagesTask"]
 
@@ -64,22 +64,16 @@ class MaxPsfWcsSelectImagesTask(WcsSelectImagesTask):
 
         Notes
         -----
-        We use the "convexHull" function in the geom package to define
+        We use the "convexHull" method in the `~lsst.sphgeom` package to define
         polygons on the celestial sphere, and test the polygon of the
         patch for overlap with the polygon of the image.
-
-        We use "convexHull" instead of generating a SphericalConvexPolygon
-        directly because the standard for the inputs to SphericalConvexPolygon
-        are pretty high and we don't want to be responsible for reaching them.
-        If "convexHull" is found to be too slow, we can revise this.
-
         """
         psf_sizes = []
         dataRefList = []
         exposureInfoList = []
 
         patchVertices = [coord.getVector() for coord in coordList]
-        patchPoly = convexHull(patchVertices)
+        patchPoly = ConvexPolygon.convexHull(patchVertices)
 
         for data in selectDataList:
             dataRef = data.dataRef
@@ -96,7 +90,7 @@ class MaxPsfWcsSelectImagesTask(WcsSelectImagesTask):
                 self.log.debug("WCS error in testing calexp %s (%s): deselecting", dataRef.dataId, e)
                 continue
 
-            imagePoly = convexHull([coord.getVector() for coord in imageCorners])
+            imagePoly = ConvexPolygon.convexHull([coord.getVector() for coord in imageCorners])
             if imagePoly is None:
                 self.log.debug("Unable to create polygon from image %s: deselecting", dataRef.dataId)
                 continue

--- a/python/lsst/ap/pipe/selectImages.py
+++ b/python/lsst/ap/pipe/selectImages.py
@@ -59,8 +59,14 @@ class MaxPsfWcsSelectImagesTask(WcsSelectImagesTask):
 
         Returns
         -------
-        pipe.base.Struct with filtered exposureList and dataRefList
-        (if makeDataRefList is True).
+        result : `lsst.pipe.base.Struct`
+            Result struct with components:
+
+            - ``exposureList``: the selected exposures
+                (`list` of `lsst.pipe.tasks.selectImages.BaseExposureInfo`).
+            - ``dataRefList``: the optional data references corresponding to
+                each element of ``exposureList``
+                (`list` of `lsst.daf.persistence.ButlerDataRef`, or `None`).
 
         Notes
         -----


### PR DESCRIPTION
This PR fixes an `ImportError` in `selectImages.py` that propagates to imports of `lsst.ap.pipe`. The `__init__` file for `ap.pipe` may also be edited as part of this PR, but I'm waiting for confirmation from @ebellm that it's safe to do so.