### PR TITLE
DM-14497: ap_pipe doesn't know filters for AssociationTask

### DIFF
--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -104,6 +104,12 @@ class ApPipeConfig(pexConfig.Config):
 
     def validate(self):
         pexConfig.Config.validate(self)
+        if not self.differencer.doMeasurement:
+            raise ValueError("Source association needs diaSource fluxes.")
+        if not self.differencer.doWriteSources:
+            raise ValueError("Source association needs diaSource catalogs.")
+        if not self.differencer.doWriteSubtractedExp:
+            raise ValueError("Source association needs difference exposures.")
 
 
 class ApPipeTask(pipeBase.CmdLineTask):

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -99,6 +99,8 @@ class ApPipeConfig(pexConfig.Config):
         self.differencer.doSelectSources = False
 
         self.associator.level1_db.retarget(AssociationDBSqliteTask)
+        # TODO: generalize in DM-12315
+        self.associator.level1_db.filter_names = ['u', 'g', 'r', 'i', 'z', 'y', 'VR', 'N964']
 
     def validate(self):
         pexConfig.Config.validate(self)


### PR DESCRIPTION
This PR updates `ApPipeConfig` to account for API changes in `AssociationTask`. It also ~adds a temporary workaround for DM-14507 (though I'm not sure why it works, since `AssociationTask` does the same thing internally) and~ improves the input validation of `ApPipeConfig`.