### PR TITLE
DM-12315: Generalize ap_pipe to non-HiTS data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *~
 pytest_session.txt
 .cache
+.coverage
 .sconf_temp
 .sconsign.dblite
 bin/*.py

--- a/Sconstruct
+++ b/Sconstruct
@@ -1,3 +1,3 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConstruct("ap_pipe")
+scripts.BasicSConstruct("ap_pipe", disableCc=True)

--- a/doc/ap_pipe/index.rst
+++ b/doc/ap_pipe/index.rst
@@ -17,7 +17,7 @@ Repository
    https://github.com/lsst-dm/ap_pipe
 
 JIRA component
-   `ap_pipe <https://jira.lsstcorp.org/issues/?jql=project %3D DM AND component %3D ap_pipe>`_
+   `ap_pipe <https://jira.lsstcorp.org/issues/?jql=project %3D DM %20AND%20 component %3D ap_pipe>`_
 
 Modules
 =======

--- a/doc/lsst.ap.pipe/getting-started.rst
+++ b/doc/lsst.ap.pipe/getting-started.rst
@@ -71,7 +71,9 @@ For the AP Pipeline to successfully process data, the following is required:
   ingested into a main Butler repository
 
   - The reference catalogs must be in a directory called `ref_cats` with subdirectories
-    called `gaia` and `pan-starrs` containing the appropriate catalog shards
+    for each catalog containing the appropriate catalog shards.
+    We recommend using Pan-STARRS for photometry and gaia for astrometry.
+    An example :ref:`config file <command-line-task-config-howto-configfile>` for using these two catalogs can be found in the `ap_verify_hits2015`_ repository.
     
 - **Calibration products** (biases, flats, and defects, if applicable)
   ingested into a Butler repository you must specify with the ``--calib`` flag on
@@ -85,19 +87,15 @@ For the AP Pipeline to successfully process data, the following is required:
   must be either in the main Butler repository or in another location you may
   specify with the ``--template`` flag on the command line at runtime
 
+.. TODO: update default for DM-14601
+
+.. _ap_verify_hits2015: https://github.com/lsst/ap_verify_hits2015/
+
 A sample dataset from the `DECam HiTS survey <http://iopscience.iop.org/article/10.3847/0004-637X/832/2/155/meta>`_ 
 that works with ``ap_pipe`` in the :ref:`ap-verify-datasets` format
-is available as `ap_verify_hits2015 
-<https://github.com/lsst/ap_verify_hits2015>`_. However, this dataset must be
+is available as `ap_verify_hits2015`_. However, this dataset must be
 ingested as described in :ref:`section-ap-pipe-ingesting-data-files`, and the reference
 catalog and defect files must be decompressed and extracted.
-
-.. warning::
-
-   `lsst.ap.pipe` has only been used on DECam (and, correspondingly, with
-   `lsst.obs.decam`) so far, and does not yet support data from other cameras.
-   This functionality is coming soon
-   (see `DM-12315 <https://jira.lsstcorp.org/browse/DM-12315>`_).
 
 Please continue to :doc:`Pipeline Tutorial <pipeline-tutorial>` for more
 details about running the AP Pipeline and interpreting the results.

--- a/doc/lsst.ap.pipe/getting-started.rst
+++ b/doc/lsst.ap.pipe/getting-started.rst
@@ -10,10 +10,10 @@ Getting started with the AP Pipeline
 Installation
 ============
 
-`lsst.ap.pipe`, available `here <https://github.com/lsst-dm/ap_pipe>`_,
+`lsst.ap.pipe`, available `from GitHub <https://github.com/lsst-dm/ap_pipe>`_,
 is not yet included with the LSST Science Pipelines stack.
-You will need to clone, setup, and build it by following the directions
-`here <https://pipelines.lsst.io/install/package-development.html>`_.
+You will need to clone, setup, and build it by following the
+`Science Pipelines documentation <https://pipelines.lsst.io/install/package-development.html>`_.
 
 .. note::
 

--- a/doc/lsst.ap.pipe/pipeline-overview.rst
+++ b/doc/lsst.ap.pipe/pipeline-overview.rst
@@ -31,4 +31,6 @@ to verify the output.
 `ap_pipe` is entirely written in Python. Key contents include:
 
 - `~lsst.ap.pipe.ApPipeTask`: a `~lsst.pipe.base.CmdLineTask` for running the entire AP Pipeline
+- `~lsst.ap.pipe.ApPipeConfig`: a config for customizing ``ApPipeTask`` for a particular dataset's needs.
+  Supported observatory packages should provide a :ref:`config override file <command-line-task-config-howto-obs>` that does most of the work.
 

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -189,8 +189,10 @@ running ap_pipe, try
 Running on other cameras
 ------------------------
 
-Only DECam data is supported for now. Please stay tuned!
+Running ap_pipe on cameras other than DECam works much the same way: you need to provide a raw repo and either a rerun or an output repo, and you may need to provide calib or template repos.
+The :ref:`calexp configuration file <section-ap-pipe-calexp-templates>` will work with any camera.
 
+You will need to use a dataId formatted appropriately for the camera; check the camera's obs package documentation or consult the :ref:`--show data<subsection-ap-pipe-previewing-dataIds>` flag.
 
 Common errors
 -------------

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -166,7 +166,7 @@ A full command looks like
 .. _section-ap-pipe-supplemental-info:
 
 Supplemental information
-======================
+========================
 
 .. _subsection-ap-pipe-previewing-dataIds:
 


### PR DESCRIPTION
This PR moves most of the config defaults out of the source code (see lsst/ap_verify_hits2015#9, lsst/obs_decam#88, and lsst/obs_subaru#143). Note that, depending on the templates or refcats being used, runs of `ap_pipe` are much more likely to need a user config file.

This PR also makes some minor maintenance updates to `ap_pipe`.