### PR TITLE
DM-15096: Cannot reuse association database with ApPipeTask reruns

### DIFF
--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -64,7 +64,7 @@ To process your ingested data, run
 
 .. prompt:: bash
    
-   ap_pipe.py repo --calib repo/calibs --rerun processed --id visit=123456 ccdnum=42 filter=g --template templates
+   ap_pipe.py repo --calib repo/calibs --rerun processed -c associator.level1_db.db_name=ppdb/association.db --id visit=123456 ccdnum=42 filter=g --template templates
 
 In this case, a ``processed`` directory will be created within
 ``repo/rerun`` and the results will be written there.
@@ -86,29 +86,35 @@ If you prefer to have a standalone output repository, you may instead run
 
 .. prompt:: bash
 
-   ap_pipe.py repo --calib repo/calibs --output path/to/put/processed/data/in --id visit=123456 ccdnum=42 filter=g --template path/to/templates
+   ap_pipe.py repo --calib repo/calibs --output path/to/put/processed/data/in -c associator.level1_db.db_name=ppdb/association.db --id visit=123456 ccdnum=42 filter=g --template path/to/templates
 
 In this case, the output directory will be created if it does not already exist.
 If you omit the ``--template`` flag, ``ap_pipe`` will assume the templates are
 somewhere in ``repo``.
 
+.. note::
+
+   If you are using the default (SQLite) association database, you must :ref:`configure <command-line-task-config-howto>` the database location, or ``ap_pipe`` will not run.
+   The location is a path to a new or existing database file to be used for source associations (including associations with previously known objects, if the database already exists).
+   In the examples above, it is configured with the ``-c`` option, but a personal config file may be more convenient if you intend to run ``ap_pipe`` many times.
 
 .. _section-ap-pipe-expected-outputs:
 
 Expected outputs
 ================
 
-If you used the rerun option above, the output from ``ap_pipe`` should be
-written out in the repo/rerun/processed directory. It should look
-something like
+If you used the rerun option above, most of the output from ``ap_pipe`` should be written out in the repo/rerun/processed directory,.
+The exception is the source association database, which will be written to the location you configure.
+The result from running ``ap_pipe`` should look something like
 
 .. code-block:: none
 
+   ppdb/
+      association.db   <--- the Prompt Products Database with DIAObjects
    repo/
       rerun/
          processed/
             repositoryCfg.yaml
-            association.db   <--- the Prompt Products Database with DIAObjects
             deepDiff/
                v123456/   <--- difference images and DIASource tables are in here
             123456/   <--- all other processed data products are in here (calexps etc.)
@@ -154,7 +160,7 @@ A full command looks like
 
 .. prompt:: bash
    
-   ap_pipe.py repo --calib repo/calibs --rerun processed -C $AP_PIPE_DIR/config/calexpTemplates.py --id visit=123456 ccdnum=42 filter=g --template /path/to/calexp/templates --templateId visit=234567
+   ap_pipe.py repo --calib repo/calibs --rerun processed -C $AP_PIPE_DIR/config/calexpTemplates.py -c associator.level1_db.db_name=ppdb/association.db --id visit=123456 ccdnum=42 filter=g --template /path/to/calexp/templates --templateId visit=234567
 
 
 .. _section-ap-pipe-supplemental-info:
@@ -223,8 +229,8 @@ calibrated exposures, difference images, inspect DIAObjects and/or DIASources, e
    butler = dafPersist.Butler(os.path.join(workingDir))
 
    # Open and read all data from the association database
-   sqliteFile = 'association.db'
-   connection = sqlite3.connect(os.path.join(workingDir, sqliteFile))
+   sqliteFile = os.path.join('ppdb', 'association.db')
+   connection = sqlite3.connect(sqliteFile)
    tables = {'obj': 'dia_objects', 'src': 'dia_sources', 'con': 'dia_objects_to_dia_sources'}
    conTable = pd.read_sql_query('select * from {0};'.format(tables['con']), connection)
    objTable = pd.read_sql_query('select * from {0};'.format(tables['obj']), connection)

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -105,11 +105,12 @@ class ApPipeConfig(pexConfig.Config):
     def validate(self):
         pexConfig.Config.validate(self)
         if not self.differencer.doMeasurement:
-            raise ValueError("Source association needs diaSource fluxes.")
+            raise ValueError("Source association needs diaSource fluxes [differencer.doMeasurement].")
         if not self.differencer.doWriteSources:
-            raise ValueError("Source association needs diaSource catalogs.")
+            raise ValueError("Source association needs diaSource catalogs [differencer.doWriteSources].")
         if not self.differencer.doWriteSubtractedExp:
-            raise ValueError("Source association needs difference exposures.")
+            raise ValueError("Source association needs difference exposures "
+                             "[differencer.doWriteSubtractedExp].")
 
 
 class ApPipeTask(pipeBase.CmdLineTask):


### PR DESCRIPTION
This PR removes the database-in-repository model from `ap_pipe` as well as all the code that was necessary to enforce it. SQLite configs are no longer allowed to specify `:memory:`, as testing revealed that in-memory databases are incompatible with the requirement that the database be fully initialized before `AssociationTask` is created. The documentation has been updated to emphasize that the user must always choose a database location in addition to the usual output repository.